### PR TITLE
add llama stack for 2.22 and fast channels

### DIFF
--- a/.wordlist-txt
+++ b/.wordlist-txt
@@ -262,6 +262,7 @@ libvirt
 lifecycle
 linter
 linux
+llamastack
 llm
 machineset
 microservices

--- a/components/operators/openshift-ai/instance/components/components-llamastack/README.md
+++ b/components/operators/openshift-ai/instance/components/components-llamastack/README.md
@@ -1,0 +1,21 @@
+# components-llamastack
+
+## Purpose
+This component is designed help configure the serving specific components including the following items:
+
+llamastack-operator
+
+## Usage
+
+This component can be added to a base by adding the `components` section to your overlay `kustomization.yaml` file:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/components-llamastack
+```

--- a/components/operators/openshift-ai/instance/components/components-llamastack/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/components/components-llamastack/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-datasciencecluster.yaml
+    target:
+      kind: DataScienceCluster

--- a/components/operators/openshift-ai/instance/components/components-llamastack/patch-datasciencecluster.yaml
+++ b/components/operators/openshift-ai/instance/components/components-llamastack/patch-datasciencecluster.yaml
@@ -1,0 +1,8 @@
+kind: DataScienceCluster
+apiVersion: datasciencecluster.opendatahub.io/v1
+metadata:
+  name: default
+spec:
+  components:
+    llamastackoperator:
+      managementState: Managed

--- a/components/operators/openshift-ai/instance/overlays/fast-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/fast-nvidia-gpu/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/auth-with-authorino
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
+  - ../../components/components-llamastack
   - ../../components/components-training
   - ../../components/components-trustyai
   - ../../components/dashboard-feature-hardware-profiles

--- a/components/operators/openshift-ai/instance/overlays/fast/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/fast/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/auth-with-authorino
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
+  - ../../components/components-llamastack
   - ../../components/components-training
   - ../../components/dashboard-feature-hardware-profiles
   - ../../components/dashboard-feature-model-catalog

--- a/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22-nvidia-gpu/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/auth-with-authorino
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
+  - ../../components/components-llamastack
   - ../../components/components-modelmesh
   - ../../components/components-training
   - ../../components/components-trustyai

--- a/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
+++ b/components/operators/openshift-ai/instance/overlays/stable-2.22/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/auth-with-authorino
   - ../../components/components-distributed-compute
   - ../../components/components-kserve
+  - ../../components/components-llamastack
   - ../../components/components-modelmesh
   - ../../components/components-training
   - ../../components/default-notebook-pvc-size


### PR DESCRIPTION
# What does this PR do?
This PR enables llamastack by default for 2.22 and fast channel releases.

## Checklist
- [ ] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
Deploy on cluster
