### PR TITLE
add odf operator

### DIFF
--- a/components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu/patch-operators-list.yaml
@@ -46,7 +46,11 @@ spec:
         values:
           name: openshift-servicemesh-operator
           path: components/operators/openshift-servicemesh/operator/overlays/stable
-
+      # - cluster: local
+      #   url: https://kubernetes.default.svc
+      #   values:
+      #     name: openshift-data-foundation-operator
+      #     path: components/operators/odf/aggregate/overlays/aws-node-labeler
       # - cluster: local
       #   url: https://kubernetes.default.svc
       #   values:

--- a/components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu/patch-operators-list.yaml
@@ -46,7 +46,11 @@ spec:
         values:
           name: openshift-servicemesh-operator
           path: components/operators/openshift-servicemesh/operator/overlays/stable
-
+      # - cluster: local
+      #   url: https://kubernetes.default.svc
+      #   values:
+      #     name: openshift-data-foundation-operator
+      #     path: components/operators/odf/aggregate/overlays/aws-node-labeler
       # - cluster: local
       #   url: https://kubernetes.default.svc
       #   values:

--- a/components/operators/odf/README.md
+++ b/components/operators/odf/README.md
@@ -1,0 +1,42 @@
+# OpenShift Data Foundation Operator
+
+Installs the OpenShift Data Foundation operator.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+The current *overlays* available are for the following channels:
+
+* [stable-4.18](operator/overlays/stable-4.18)
+* [stable-4.17](operator/overlays/stable-4.17)
+* [stable-4.16](operator/overlays/stable-4.16)
+* [stable-4.15](operator/overlays/stable-4.15)
+* [stable-4.14](operator/overlays/stable-4.14)
+* [stable-4.13](operator/overlays/stable-4.13)
+* [stable-4.12](operator/overlays/stable-4.12)
+* [stable-4.11](operator/overlays/stable-4.11)
+* [stable-4.10](operator/overlays/stable-4.10)
+* [stable-4.9](operator/overlays/stable-4.9)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the OpenShift Data Foundation operator based on the overlay of your choice by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-data-foundation-operator/operator/overlays/<channel>
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/operator/overlays/<channel>
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/operator/overlays/<channel>?ref=main
+```

--- a/components/operators/odf/aggregate/overlays/aws-node-labeler/kustomization.yaml
+++ b/components/operators/odf/aggregate/overlays/aws-node-labeler/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - ../../../operator/overlays/stable-4.18
+  - ../../../instance/overlays/aws
+  - ../../../config-helpers/aws-cpu-infra-machineset/overlays/default
+  - ../../../config-helpers/node-labeler/overlays/default

--- a/components/operators/odf/aggregate/overlays/aws/kustomization.yaml
+++ b/components/operators/odf/aggregate/overlays/aws/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - ../../../operator/overlays/stable-4.18
+  - ../../../instance/overlays/aws

--- a/components/operators/odf/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
+++ b/components/operators/odf/aggregate/overlays/vsphere-node-labeler/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/vsphere
+  - ../../../config-helpers/node-labeler/overlays/default

--- a/components/operators/odf/aggregate/overlays/vsphere/kustomization.yaml
+++ b/components/operators/odf/aggregate/overlays/vsphere/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../operator/overlays/stable-4.9
+  - ../../../instance/overlays/vsphere

--- a/components/operators/odf/config-helpers/README.md
+++ b/components/operators/odf/config-helpers/README.md
@@ -1,0 +1,38 @@
+# OpenShift Data Foundation - Config Helpers
+
+Configuration helpers useful for automating some configurations needed to setup the operator.
+
+## Node Labeler
+
+The [node-labeler](/node-labeler/) is a helpful addition to any ODF instance overlays and can be used in combination with them.
+
+node-labeler creates a job that is responsible for applying the `cluster.ocs.openshift.io/openshift-storage=""` label to nodes needed for the ODF/OCS to install.  If your cluster does not have the minimum three worker nodes the job will fail.
+
+### Overlays
+
+The node-labeler config helper for this operator currently offers the following *overlays*:
+* [default](overlays/default)
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/config-helpers/node-labeler/overlays/default?ref=main
+```

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/README.md
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/README.md
@@ -1,0 +1,27 @@
+# aws-cpu-infra-machineset
+
+## Purpose
+
+This component is designed to setup a MachineSet with cpu-infras on an AWS based OpenShift cluster.
+
+This component triggers a job that creates a MachineSet based on your current MachineSet.
+
+This component has been tested using AWS based OpenShift instances provisioned by demo.redhat.com.
+
+## Usage
+
+This component can be added to a base by adding the `components` section to your overlay `kustomization.yaml` file:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/aws-cpu-infra-machineset
+```
+
+
+You can customize the taint applied to the cpu-infra nodes by updating [machineset-patch.yaml](./machineset-patch.yaml) file.

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/job.sh
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/job.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+set -e
+
+ocp_aws_cluster(){
+  TARGET_NS=kube-system
+  OBJ=secret/aws-creds
+  echo "Checking if ${OBJ} exists in ${TARGET_NS} namespace"
+  oc -n "${TARGET_NS}" get "${OBJ}" -o name > /dev/null 2>&1 || return 1
+  echo "AWS cluster detected"
+}
+
+ocp_aws_create_cpu_infra_machineset(){
+  
+  INSTANCE_TYPE=${1:-m6a.4xlarge	}
+
+  ocp_aws_clone_machineset "${INSTANCE_TYPE}"
+
+  MACHINE_SET_TYPE=$(oc -n openshift-machine-api get machinesets.machine.openshift.io -o name | grep "${INSTANCE_TYPE%.*}" | head -n1)
+
+  PATCH_FILE="$(dirname "$0")/machineset-patch.yaml"
+
+  if [ -f ${PATCH_FILE} ]; then
+    echo "Patching ${MACHINE_SET_TYPE} with ${PATCH_FILE}."
+    oc -n openshift-machine-api \
+      patch "${MACHINE_SET_TYPE}" \
+      --type=merge --patch-file ${PATCH_FILE}
+  else
+    echo "Unable to taint nodes, patch file ${PATCH_FILE} not found."
+    exit 1
+  fi
+ 
+  oc -n openshift-machine-api \
+    patch "${MACHINE_SET_TYPE}" \
+    --type=merge --patch '{"spec":{"template":{"spec":{"providerSpec":{"value":{"instanceType":"'"${INSTANCE_TYPE}"'"}}}}}}'
+}
+
+ocp_aws_clone_machineset(){
+  [ -z "${1}" ] && \
+  echo "
+    usage: ocp_aws_create_cpu_infra_machineset < instance type, default m6a.4xlarge	 >
+  "
+
+  INSTANCE_TYPE=${1:-m6a.4xlarge	}
+  MACHINE_SET=$(oc -n openshift-machine-api get machinesets.machine.openshift.io -o name | grep worker | head -n1)
+
+  # check for an existing instance machine set
+  if oc -n openshift-machine-api get machinesets.machine.openshift.io -o name | grep -q "${INSTANCE_TYPE%.*}"; then
+    echo "Exists: machineset - ${INSTANCE_TYPE}"
+  else
+    echo "Creating: machineset - ${INSTANCE_TYPE}"
+    oc -n openshift-machine-api \
+      get "${MACHINE_SET}" -o yaml | \
+        sed '/machine/ s/-worker/-'"${INSTANCE_TYPE}"'/g
+          /name/ s/-worker/-'"infra-${INSTANCE_TYPE%.*}"'/g
+          s/instanceType.*/instanceType: '"${INSTANCE_TYPE}"'/
+          s/replicas.*/replicas: 3/' | \
+      oc apply -f -
+  fi
+}
+
+# ocp_create_machineset_autoscale(){
+#   MACHINE_MIN=${1:-0}
+#   MACHINE_MAX=${2:-3}
+#   MACHINE_SETS=${3:-$(oc -n openshift-machine-api get machinesets.machine.openshift.io -o name | sed 's@.*/@@' )}
+
+#   for set in ${MACHINE_SETS}
+#   do
+# cat << YAML | oc apply -f -
+# apiVersion: "autoscaling.openshift.io/v1beta1"
+# kind: "MachineAutoscaler"
+# metadata:
+#   name: "${set}"
+#   namespace: "openshift-machine-api"
+# spec:
+#   minReplicas: ${MACHINE_MIN}
+#   maxReplicas: ${MACHINE_MAX}
+#   scaleTargetRef:
+#     apiVersion: machine.openshift.io/v1beta1
+#     kind: MachineSet
+#     name: "${set}"
+# YAML
+#   done
+# }
+
+INSTANCE_TYPE=${INSTANCE_TYPE:-m6a.4xlarge	}
+
+ocp_aws_cluster || exit 0
+ocp_aws_create_cpu_infra_machineset ${INSTANCE_TYPE}
+# ocp_create_machineset_autoscale

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/job.yaml
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/job.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: job-aws-cpu-infra-machineset-
+  name: job-aws-cpu-infra-machineset
+  namespace: openshift-machine-api
+  # annotations:
+  #   argocd.argoproj.io/hook: Sync
+    # argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      containers:
+        - name: job-aws-cpu-infra-machineset
+          # image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          image: registry.redhat.io/openshift4/ose-cli
+          env:
+            - name: INSTANCE_TYPE
+              value: "m6a.4xlarge	"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          command:
+            - /bin/bash
+            - -c
+            - /scripts/job.sh
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+      volumes:
+        - name: scripts
+          configMap:
+            name: job-aws-cpu-infra-machineset
+            defaultMode: 0755
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 30
+      serviceAccount: job-aws-cpu-infra-machineset
+      serviceAccountName: job-aws-cpu-infra-machineset

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/kustomization.yaml
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-machine-api
+
+resources:
+  - job.yaml
+  - rbac.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: job-aws-cpu-infra-machineset
+    namespace: openshift-machine-api
+    files:
+      - job.sh
+      - machineset-patch.yaml

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/machineset-patch.yaml
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/machineset-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    cluster.ocs.openshift.io/openshift-storage: ""
+    machine.openshift.io/cluster-api-machine-role: infra
+    machine.openshift.io/cluster-api-machine-type: infra
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        node-role.kubernetes.io/infra: ""
+        cluster.ocs.openshift.io/openshift-storage: ""
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/infra: ""
+          cluster.ocs.openshift.io/openshift-storage: ""

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/rbac.yaml
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/base/rbac.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-aws-cpu-infra-machineset
+  namespace: openshift-machine-api
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: job-aws-cpu-infra-machineset
+rules:
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machinesets
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - machineautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  resourceNames:
+  - aws-creds
+  verbs:
+  - get
+  - list
+# - nonResourceURLs:
+#   - '*'
+#   verbs:
+#   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-aws-cpu-infra-machineset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-aws-cpu-infra-machineset
+subjects:
+  - kind: ServiceAccount
+    name: job-aws-cpu-infra-machineset
+    namespace: openshift-machine-api

--- a/components/operators/odf/config-helpers/aws-cpu-infra-machineset/overlays/default/kustomization.yaml
+++ b/components/operators/odf/config-helpers/aws-cpu-infra-machineset/overlays/default/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-machine-api
+
+resources:
+  - ../../base

--- a/components/operators/odf/config-helpers/node-labeler/base/kustomization.yaml
+++ b/components/operators/odf/config-helpers/node-labeler/base/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - node-label-job.yaml
+  - rbac.yaml

--- a/components/operators/odf/config-helpers/node-labeler/base/node-label-job.yaml
+++ b/components/operators/odf/config-helpers/node-labeler/base/node-label-job.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-cluster-label-worker-nodes
+  generateName: storage-cluster-label-worker-nodes-
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  template:
+    spec:
+      containers:
+        - name: labeler
+          image: registry.redhat.io/openshift4/ose-cli
+          env:
+            - name: selector
+              value: 'node-role.kubernetes.io/worker'
+          command:
+            - /bin/bash
+            - -c
+            - |
+              node_count=$(oc get nodes --selector=${selector} --output name | wc -l)
+              if [ ${node_count} -lt 3 ]; then
+                echo "Not enough selected nodes present in cluster"
+                oc get nodes --selector=${selector}
+                exit 1
+              fi
+              echo "Labeling the following nodes"
+              oc get nodes --selector=${selector}
+              oc label nodes --selector=${selector} cluster.ocs.openshift.io/openshift-storage="" --overwrite=true
+      restartPolicy: Never
+      serviceAccount: ocs-node-labeler
+      serviceAccountName: ocs-node-labeler
+  backoffLimit: 4

--- a/components/operators/odf/config-helpers/node-labeler/base/rbac.yaml
+++ b/components/operators/odf/config-helpers/node-labeler/base/rbac.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocs-node-labeler
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-labeler
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-5"
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - label
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: node-labeler
+  namespace: openshift-storage
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "-4"
+subjects:
+  - kind: ServiceAccount
+    name: ocs-node-labeler
+    namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-labeler

--- a/components/operators/odf/config-helpers/node-labeler/overlays/default/kustomization.yaml
+++ b/components/operators/odf/config-helpers/node-labeler/overlays/default/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - ../../base

--- a/components/operators/odf/instance/README.md
+++ b/components/operators/odf/instance/README.md
@@ -1,0 +1,64 @@
+# OpenShift Data Foundation
+
+Installs a basic Storage System using the OpenShift Data Foundation Operator.
+
+## Prerequisites
+
+OpenShift Data Foundation requires a minimum three worker nodes to install and configure a ceph cluster using OpenShift Data Foundation.
+
+First, install the [OpenShift Data Foundation Operator](../operator) in your cluster.
+
+Do not use the `base` directory directly, as you will need to patch the `channel` based on the version of OpenShift you are using, or the version of the operator you want to use.
+
+## Overlays
+
+The options for this operator are the following *overlays*:
+
+* [aws](overlays/aws)
+* [vsphere](overlays/vsphere)
+
+In order for ODF/OCS to configure storage using the overlays, they expect nodes with the following label to be present on the nodes ODF/OCS will install the cluster:
+
+```
+cluster.ocs.openshift.io/openshift-storage=""
+```
+
+You will need to manually add this label to nodes if they are not already present:
+
+```
+oc label nodes <node-name> cluster.ocs.openshift.io/openshift-storage="" --overwrite=true
+```
+
+For additional automation for labeling nodes see [node-labeler](../config-helpers/node-labeler/)
+
+### AWS
+
+[aws](overlays/aws) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitialization object to configure the storage cluster.  The StorageCluster is configured to work with gp2 storage on an AWS cluster.
+
+### vSphere
+
+[vsphere](overlays/vsphere) installs a basic StorageSystem.  The StorageSystem will configure the OpenShift Container Storage Operator and also install a StorageCluster and OCSInitialization object to configure the storage cluster.  The StorageCluster is configured to work with thin storage on a vSphere cluster and enables flexible scaling to distribute devices evenly across all nodes, regardless of distribution in zones or racks.
+
+## Usage
+
+If you have cloned the `gitops-catalog` repository, you can install the Storage System by running from the root `gitops-catalog` directory
+
+```
+oc apply -k openshift-data-foundation-operator/instance/overlays/default
+```
+
+Or, without cloning:
+
+```
+oc apply -k https://github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/instance/overlays/default
+```
+
+As part of a different overlay in your own GitOps repo:
+
+```
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-cop/gitops-catalog/openshift-data-foundation-operator/instance/overlays/default?ref=main
+```

--- a/components/operators/odf/instance/base/kustomization.yaml
+++ b/components/operators/odf/instance/base/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - storagesystem.yaml

--- a/components/operators/odf/instance/base/storagesystem.yaml
+++ b/components/operators/odf/instance/base/storagesystem.yaml
@@ -1,0 +1,8 @@
+apiVersion: odf.openshift.io/v1alpha1
+kind: StorageSystem
+metadata:
+  name: ocs-storagecluster-storagesystem
+spec:
+  kind: storagecluster.ocs.openshift.io/v1
+  name: ocs-storagecluster
+  namespace: openshift-storage

--- a/components/operators/odf/instance/overlays/aws/kustomization.yaml
+++ b/components/operators/odf/instance/overlays/aws/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - ../../base
+  - ocsinitialization.yaml
+  - storagecluster.yaml

--- a/components/operators/odf/instance/overlays/aws/ocsinitialization.yaml
+++ b/components/operators/odf/instance/overlays/aws/ocsinitialization.yaml
@@ -1,0 +1,7 @@
+apiVersion: ocs.openshift.io/v1
+kind: OCSInitialization
+metadata:
+  name: ocsinit
+  namespace: openshift-storage
+spec:
+  enableCephTools: true

--- a/components/operators/odf/instance/overlays/aws/storagecluster.yaml
+++ b/components/operators/odf/instance/overlays/aws/storagecluster.yaml
@@ -1,0 +1,39 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  managedResources:
+    cephBlockPools: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+  mirroring: {}
+  nodeTopologies: {}
+  storageDeviceSets:
+    - config: {}
+      count: 1
+      dataPVCTemplate:
+        metadata: {}
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Ti
+          storageClassName: gp2-csi
+          volumeMode: Block
+        status: {}
+      name: ocs-deviceset-gp2
+      placement: {}
+      portable: true
+      preparePlacement: {}
+      replica: 3
+      resources: {}

--- a/components/operators/odf/instance/overlays/vsphere/kustomization.yaml
+++ b/components/operators/odf/instance/overlays/vsphere/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - ../../base
+  - ocsinitialization.yaml
+  - storagecluster.yaml

--- a/components/operators/odf/instance/overlays/vsphere/ocsinitialization.yaml
+++ b/components/operators/odf/instance/overlays/vsphere/ocsinitialization.yaml
@@ -1,0 +1,7 @@
+apiVersion: ocs.openshift.io/v1
+kind: OCSInitialization
+metadata:
+  name: ocsinit
+  namespace: openshift-storage
+spec:
+  enableCephTools: true

--- a/components/operators/odf/instance/overlays/vsphere/storagecluster.yaml
+++ b/components/operators/odf/instance/overlays/vsphere/storagecluster.yaml
@@ -1,0 +1,40 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  arbiter: {}
+  encryption:
+    kms: {}
+  externalStorage: {}
+  flexibleScaling: true
+  managedResources:
+    cephBlockPools: {}
+    cephConfig: {}
+    cephDashboard: {}
+    cephFilesystems: {}
+    cephObjectStoreUsers: {}
+    cephObjectStores: {}
+  mirroring: {}
+  nodeTopologies: {}
+  storageDeviceSets:
+    - config: {}
+      count: 1
+      dataPVCTemplate:
+        metadata: {}
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 2Ti
+          storageClassName: thin
+          volumeMode: Block
+        status: {}
+      name: ocs-deviceset-thin
+      placement: {}
+      portable: true
+      preparePlacement: {}
+      replica: 3
+      resources: {}

--- a/components/operators/odf/operator/base/enable-console-plugin-job.yaml
+++ b/components/operators/odf/operator/base/enable-console-plugin-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: enable-odf-console-plugin
+  generateName: enable-odf-console-plugin-
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+spec:
+  template:
+    spec:
+      containers:
+        - name: labeler
+          image: registry.redhat.io/openshift4/ose-cli
+          env:
+            - name: PLUGIN_NAME
+              value: 'odf-console'
+          command:
+            - /bin/bash
+            - -c
+            - |
+                echo "Attempting to enable ${PLUGIN_NAME} plugin"
+                echo ""
+
+                # Create the plugins section on the object if it doesn't exist
+                if [ -z $(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}') ]; then
+                  echo "Creating plugins object"
+                  oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": [] } }' --type=merge
+                fi
+
+                INSTALLED_PLUGINS=$(oc get consoles.operator.openshift.io cluster -o=jsonpath='{.spec.plugins}')
+                echo "Current plugins:"
+                echo ${INSTALLED_PLUGINS}
+
+                if [[ "${INSTALLED_PLUGINS}" == *"${PLUGIN_NAME}"* ]]; then
+                    echo "${PLUGIN_NAME} is already enabled"
+                else
+                    echo "Enabling plugin: ${PLUGIN_NAME}"
+                    oc patch consoles.operator.openshift.io cluster --type=json --patch '[{"op": "add", "path": "/spec/plugins/-", "value": "'${PLUGIN_NAME}'"}]'
+                fi
+      restartPolicy: Never
+      serviceAccount: enable-odf-console-plugin
+      serviceAccountName: enable-odf-console-plugin
+  backoffLimit: 4

--- a/components/operators/odf/operator/base/enable-console-plugin-rbac.yaml
+++ b/components/operators/odf/operator/base/enable-console-plugin-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: enable-odf-console-plugin
+rules:
+  - apiGroups: ["operator.openshift.io"]
+    resources:
+      - consoles
+    verbs:
+      - get
+      - list
+      - patch
+      - label
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: enable-odf-console-plugin
+subjects:
+  - kind: ServiceAccount
+    name: enable-odf-console-plugin
+    namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enable-odf-console-plugin

--- a/components/operators/odf/operator/base/enable-console-plugin-sa.yaml
+++ b/components/operators/odf/operator/base/enable-console-plugin-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enable-odf-console-plugin

--- a/components/operators/odf/operator/base/kustomization.yaml
+++ b/components/operators/odf/operator/base/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+resources:
+  - enable-console-plugin-job.yaml
+  - enable-console-plugin-rbac.yaml
+  - enable-console-plugin-sa.yaml
+  - openshift-data-foundation-console-plugin.yaml
+  - namespace.yaml
+  - operator-group.yaml
+  - subscription.yaml

--- a/components/operators/odf/operator/base/namespace.yaml
+++ b/components/operators/odf/operator/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/operators/odf/operator/base/openshift-data-foundation-console-plugin.yaml
+++ b/components/operators/odf/operator/base/openshift-data-foundation-console-plugin.yaml
@@ -1,0 +1,13 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: odf-console
+spec:
+  displayName: ODF Plugin
+  backend:
+    service:
+      basePath: /
+      name: odf-console-service
+      namespace: openshift-storage
+      port: 9001
+    type: Service

--- a/components/operators/odf/operator/base/operator-group.yaml
+++ b/components/operators/odf/operator/base/operator-group.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage

--- a/components/operators/odf/operator/base/subscription.yaml
+++ b/components/operators/odf/operator/base/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: odf-operator
+  namespace: openshift-storage
+spec:
+  channel: patch-me-see-overlays-dir
+  installPlanApproval: Automatic
+  name: odf-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/operators/odf/operator/overlays/stable-4.10/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.10/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.10* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.10/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.10/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.10/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.10/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.10

--- a/components/operators/odf/operator/overlays/stable-4.11/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.11/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.11* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.11/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.11/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.11/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.11/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.11

--- a/components/operators/odf/operator/overlays/stable-4.12/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.12/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.12* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.12/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.12/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.12/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.12/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.12

--- a/components/operators/odf/operator/overlays/stable-4.13/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.13/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.13* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.13/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.13/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.13/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.13/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.13

--- a/components/operators/odf/operator/overlays/stable-4.14/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.14/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.14* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.14/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.14/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.14/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.14/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.14

--- a/components/operators/odf/operator/overlays/stable-4.15/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.15/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.15* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.15/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.15/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.15/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.15/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.15

--- a/components/operators/odf/operator/overlays/stable-4.16/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.16/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.16* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.16/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.16/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.16/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.16/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.16

--- a/components/operators/odf/operator/overlays/stable-4.17/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.17/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.17* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.17/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.17/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.17/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.17/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.17

--- a/components/operators/odf/operator/overlays/stable-4.18/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.18/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.18* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.18/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.18/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.18/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.18/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.18

--- a/components/operators/odf/operator/overlays/stable-4.9/README.md
+++ b/components/operators/odf/operator/overlays/stable-4.9/README.md
@@ -1,0 +1,1 @@
+Installs the *stable-4.9* channel version of the OpenShift Data Foundation Operator

--- a/components/operators/odf/operator/overlays/stable-4.9/kustomization.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.9/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-storage
+
+
+resources:
+  - ../../base
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: odf-operator
+      namespace: openshift-storage
+      version: v1alpha1

--- a/components/operators/odf/operator/overlays/stable-4.9/patch-channel.yaml
+++ b/components/operators/odf/operator/overlays/stable-4.9/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-4.9


### PR DESCRIPTION
# What does this PR do?
Installs ODF Operator and creates storage classes and cluster with RWX capabilities on top of AWS GP2 storage.

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
New empty cluster, bootstrap an overlay with this operator added to patch-operator-list.yaml
```
      - cluster: local
         url: https://kubernetes.default.svc
         values:
           name: openshift-data-foundation-operator
           path: components/operators/odf/aggregate/overlays/aws-node-labeler
```

* Set a new machineset for infra nodes
* When nodes are spun up, it labels them for storage
* ODF operator installs
