### PR TITLE
Enable ArgoCD Progressive Sync feature

### DIFF
--- a/components/operators/openshift-gitops/instance/base/openshift-gitops.yaml
+++ b/components/operators/openshift-gitops/instance/base/openshift-gitops.yaml
@@ -70,6 +70,8 @@ spec:
         enabled: false
       route:
         enabled: false
+    extraCommandArgs:
+      - --enable-progressive-syncs
   rbac:
     policy: |
       g, system:cluster-admins, role:admin


### PR DESCRIPTION
# What does this PR do?

This PR enables ArgoCD's [Progressive Syncs](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/) feature on the Openshift GitOps operator.

This feature enables basic application deployment ordering by the ArgoCD controller, when specified.

## Checklist

- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan

Deploy the AI Accelerator to an Openshift cluster and then check if the `openshift-gitops` `ArgoCD` instance has the parameter added:

```sh
$ oc get argocd/openshift-gitops -n openshift-gitops -o jsonpath='{.spec.applicationSet.extraArguments[0]}'
--enable-progressive-syncs
```

There is no changes on ArgoCD's UI or current application deployment.

## Documentation

- [ArgoCD Progressive Syncs](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/)
