### PR TITLE
pin to v25.3 gpu operator to prevent errors with 25.10.1 driver

### DIFF
--- a/components/argocd/apps/overlays/rhoai-eus-2.16-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-eus-2.16-aws-gpu/patch-operators-list.yaml
@@ -15,7 +15,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: nvidia-gpu-operator
-          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/argocd/apps/overlays/rhoai-fast-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-fast-aws-gpu/patch-operators-list.yaml
@@ -15,7 +15,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: nvidia-gpu-operator
-          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu/patch-operators-list.yaml
@@ -15,7 +15,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: nvidia-gpu-operator
-          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu/patch-operators-list.yaml
@@ -15,7 +15,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: nvidia-gpu-operator
-          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/argocd/apps/overlays/rhoai-stable-2.25-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-2.25-aws-gpu/patch-operators-list.yaml
@@ -15,7 +15,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: nvidia-gpu-operator
-          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3/kustomization.yaml
+++ b/components/operators/gpu-operator-certified/aggregate/overlays/aws-v25.3/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - ../../../operator/overlays/v25.3
+  - ../../../instance/overlays/aws

--- a/components/operators/gpu-operator-certified/operator/overlays/v25.3/kustomization.yaml
+++ b/components/operators/gpu-operator-certified/operator/overlays/v25.3/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: gpu-operator-certified
+    path: patch-channel.yaml

--- a/components/operators/gpu-operator-certified/operator/overlays/v25.3/patch-channel.yaml
+++ b/components/operators/gpu-operator-certified/operator/overlays/v25.3/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: v25.3


### PR DESCRIPTION
# What does this PR do?
v25.10.1 version of the GPU operator updated to newer version of the CUDA driver which breaks compatibility with CUDA 12.x.

This reverts the GPU install to an older version of the GPU operator which installs a version of the operator which is compatible with the RHOAI containers.

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
Tested manually deploying 25.3 version of the operator.

[//]: # (## Documentation)
