### PR TITLE
update ip shortname to installplan

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -53,7 +53,7 @@ install_gitops(){
     echo "$INSTALL_PLAN_NAME was found in the namespace $OPERATOR_NS"
 
     echo -n "Retrieving the CSV name: "
-    CSV_NAME=$(oc get ip $INSTALL_PLAN_NAME -n ${OPERATOR_NS} -o jsonpath='{.spec.clusterServiceVersionNames[0]}')
+    CSV_NAME=$(oc get installplans $INSTALL_PLAN_NAME -n ${OPERATOR_NS} -o jsonpath='{.spec.clusterServiceVersionNames[0]}')
     echo "$CSV_NAME"
 
     echo "Waiting for the GitOps Operator installation to complete..."


### PR DESCRIPTION
# What does this PR do?
Closes #157 

Script was doing `get ip` and `ip` is now a short name for both `installplans` and `ipaddresses` objects.

This script updates from the shortname to the fully qualified name

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
Tested bootstrap on cluster

[//]: # (## Documentation)
