### PR TITLE
Migrate to ConfigMap generator pattern for git repository configuration

### DIFF
--- a/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.16-aws-gpu
   - ../../base
@@ -23,19 +21,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.16-aws-gpu
   - ../../base
@@ -17,6 +19,14 @@ resources:
 #     group: argoproj.io
 #     kind: Application
 #     version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -47,8 +57,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
@@ -6,6 +6,14 @@ namespace: openshift-gitops
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.16
   - ../../base
+
+# Git repository configuration (single source of truth)
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
+
 # patches:
 # set the repo and branch for applications
 # Uncomment patches to disable automatic sync
@@ -21,20 +29,30 @@ resources:
 #     version: v1alpha1
 
 replacements:
-  # copy the repo from the application to the applicationsets
+  # Inject git repository URL from ConfigMap to all Applications and ApplicationSets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      name: gitops-repo-config
+      fieldPath: data.repoURL
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
-  # copy the branch from the application to the applicationsets
+  # Inject git branch/revision from ConfigMap to all Applications and ApplicationSets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      name: gitops-repo-config
+      fieldPath: data.targetRevision
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:

--- a/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
+++ b/clusters/overlays/rhoai-eus-2.16/kustomization.yaml
@@ -6,14 +6,6 @@ namespace: openshift-gitops
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-eus-2.16
   - ../../base
-
-# Git repository configuration (single source of truth)
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main
-
 # patches:
 # set the repo and branch for applications
 # Uncomment patches to disable automatic sync
@@ -27,6 +19,14 @@ configMapGenerator:
 #     group: argoproj.io
 #     kind: Application
 #     version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # Inject git repository URL from ConfigMap to all Applications and ApplicationSets

--- a/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast-3.x-aws-gpu
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast-3.x-aws-gpu
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-3.x-aws-gpu/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast-aws-gpu
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast-aws-gpu
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-fast/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-fast/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-fast/kustomization.yaml
+++ b/clusters/overlays/rhoai-fast/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-fast
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.19-aws-gpu
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.19
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.19/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.19
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.22-aws-gpu
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
@@ -6,6 +6,14 @@ namespace: openshift-gitops
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.22
   - ../../base
+
+# Git repository configuration (single source of truth)
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
+
 # patches:
 #   Uncomment patches to disable automatic sync
 #   - path: patch-applicationset-manual-sync.yaml
@@ -20,20 +28,30 @@ resources:
 #       version: v1alpha1
 
 replacements:
-  # copy the repo from the application to the applicationsets
+  # Inject git repository URL from ConfigMap to all Applications and ApplicationSets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      name: gitops-repo-config
+      fieldPath: data.repoURL
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
-  # copy the branch from the application to the applicationsets
+  # Inject git branch/revision from ConfigMap to all Applications and ApplicationSets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      name: gitops-repo-config
+      fieldPath: data.targetRevision
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:

--- a/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.22/kustomization.yaml
@@ -6,14 +6,6 @@ namespace: openshift-gitops
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.22
   - ../../base
-
-# Git repository configuration (single source of truth)
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main
-
 # patches:
 #   Uncomment patches to disable automatic sync
 #   - path: patch-applicationset-manual-sync.yaml
@@ -26,6 +18,14 @@ configMapGenerator:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # Inject git repository URL from ConfigMap to all Applications and ApplicationSets

--- a/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25-aws-gpu
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25-aws-gpu/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25-aws-gpu
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25
   - ../../base
@@ -22,19 +20,34 @@ resources:
 replacements:
   # copy the repo from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.repoURL
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.repoURL
   # copy the branch from the application to the applicationsets
   - source:
-      kind: Application
-      fieldPath: spec.source.targetRevision
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
     targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
       - select:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25
   - ../../base
@@ -18,11 +20,13 @@ resources:
 #       version: v1alpha1
 
 # Git repository configuration (single source of truth)
+
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
+
 replacements:
   # copy the repo from the application to the applicationsets
   - source:

--- a/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 namespace: openshift-gitops
-
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25
   - ../../base
@@ -20,13 +18,11 @@ resources:
 #       version: v1alpha1
 
 # Git repository configuration (single source of truth)
-
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
+      - repoURL=https://github.com/lautou/ai-accelerator.git
       - targetRevision=main
-
 replacements:
   # copy the repo from the application to the applicationsets
   - source:

--- a/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: openshift-gitops
+
 resources:
   - ../../../components/argocd/apps/overlays/rhoai-stable-2.25
   - ../../base
@@ -16,6 +18,14 @@ resources:
 #       group: argoproj.io
 #       kind: Application
 #       version: v1alpha1
+
+# Git repository configuration (single source of truth)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - targetRevision=main
 
 replacements:
   # copy the repo from the application to the applicationsets
@@ -46,8 +56,3 @@ replacements:
           kind: ApplicationSet
         fieldPaths:
           - spec.template.spec.source.targetRevision
-configMapGenerator:
-  - name: gitops-repo-config
-    literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
-      - targetRevision=main

--- a/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
+++ b/clusters/overlays/rhoai-stable-2.25/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 configMapGenerator:
   - name: gitops-repo-config
     literals:
-      - repoURL=https://github.com/lautou/ai-accelerator.git
+      - repoURL=https://github.com/redhat-ai-services/ai-accelerator.git
       - targetRevision=main
 
 replacements:

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -181,8 +181,8 @@ wait_for_openshift_gitops(){
 }
 
 check_branch(){
-  APP_PATCH_FILE="./components/argocd/apps/base/cluster-config-app-of-apps.yaml"
-  APP_PATCH_PATH=".spec.source.targetRevision"
+  # New: Read from cluster overlay's configMapGenerator instead of base Application
+  CLUSTER_KUSTOMIZATION="./clusters/overlays/${bootstrap_dir}/kustomization.yaml"
 
   if ! command -v yq &> /dev/null; then
     print_warning "yq could not be found.  We are unable to verify the branch of your repo."
@@ -190,18 +190,20 @@ check_branch(){
   fi
 
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  APP_BRANCH=$(yq -r "${APP_PATCH_PATH}" ${APP_PATCH_FILE})
 
-  if [[ ${GIT_BRANCH} == ${APP_BRANCH} ]] ; then
+  # Extract targetRevision from configMapGenerator literal
+  OVERLAY_BRANCH=$(yq -r '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[]' ${CLUSTER_KUSTOMIZATION} | grep "^targetRevision=" | cut -d= -f2)
+
+  if [[ ${GIT_BRANCH} == ${OVERLAY_BRANCH} ]] ; then
     echo
-    echo "Your working branch ${GIT_BRANCH}, matches your cluster overlay branch ${APP_BRANCH}"
-  else 
+    echo "Your working branch ${GIT_BRANCH}, matches your cluster overlay branch ${OVERLAY_BRANCH}"
+  else
     echo
-    echo "Your current working branch is ${GIT_BRANCH}, and your cluster overlay branch is ${APP_BRANCH}."
+    echo "Your current working branch is ${GIT_BRANCH}, and your cluster overlay branch is ${OVERLAY_BRANCH}."
 
     if [[ ${FORCE} == "true" ]] ; then
       echo "Updating to ${GIT_BRANCH}"
-      update_branch ${CLUSTER_OVERLAY};
+      update_configmap_branch ${CLUSTER_KUSTOMIZATION} ${GIT_BRANCH}
     else
       echo "Do you wish to update it to ${GIT_BRANCH}?"
 
@@ -209,7 +211,7 @@ check_branch(){
 
       select yn in "Yes" "No"; do
           case $yn in
-              Yes ) update_branch ${APP_PATCH_FILE} ${APP_PATCH_PATH}; break;;
+              Yes ) update_configmap_branch ${CLUSTER_KUSTOMIZATION} ${GIT_BRANCH}; break;;
               No ) break;;
           esac
       done
@@ -286,9 +288,65 @@ update_repo(){
   git push origin ${GIT_BRANCH}
 }
 
+update_configmap_repo(){
+  if [ -z "$1" ]; then
+    echo "No kustomization file supplied."
+    exit 1
+  else
+    KUSTOMIZATION_FILE=$1
+  fi
+
+  if [ -z "$2" ]; then
+    echo "No repo URL provided."
+    exit 1
+  else
+    REPO_URL=$2
+  fi
+
+  echo "Updating ${KUSTOMIZATION_FILE}..."
+
+  # Update the repoURL literal in the configMapGenerator
+  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | startswith("repoURL="))) = "repoURL='${REPO_URL}'"' ${KUSTOMIZATION_FILE}
+
+  GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+  git add ${KUSTOMIZATION_FILE}
+  git commit -m "Update repository URL to ${REPO_URL} (automatic update by bootstrap script)"
+  git push origin ${GIT_BRANCH}
+
+  echo "✅ Updated repository URL to ${REPO_URL}"
+}
+
+update_configmap_branch(){
+  if [ -z "$1" ]; then
+    echo "No kustomization file supplied."
+    exit 1
+  else
+    KUSTOMIZATION_FILE=$1
+  fi
+
+  if [ -z "$2" ]; then
+    echo "No branch provided."
+    exit 1
+  else
+    BRANCH=$2
+  fi
+
+  echo "Updating ${KUSTOMIZATION_FILE}..."
+
+  # Update the targetRevision literal in the configMapGenerator
+  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | startswith("targetRevision="))) = "targetRevision='${BRANCH}'"' ${KUSTOMIZATION_FILE}
+
+  git add ${KUSTOMIZATION_FILE}
+  git commit -m "Update branch to ${BRANCH} (automatic update by bootstrap script)"
+  git push origin ${BRANCH}
+
+  echo "✅ Updated branch to ${BRANCH}"
+}
+
 check_repo(){
-  APP_PATCH_FILE="./components/argocd/apps/base/cluster-config-app-of-apps.yaml"
-  APP_PATCH_PATH=".spec.source.repoURL"
+  # New: Read from cluster overlay's configMapGenerator instead of base Application
+  CLUSTER_KUSTOMIZATION="./clusters/overlays/${bootstrap_dir}/kustomization.yaml"
 
   if ! command -v yq &> /dev/null; then
     echo "yq could not be found.  We are unable to verify the repo."
@@ -296,12 +354,14 @@ check_repo(){
 
     GIT_REPO=$(git config --get remote.origin.url)
     GIT_REPO_BASENAME=$(get_git_basename ${GIT_REPO})
-    APP_REPO=$(yq -r "${APP_PATCH_PATH}" ${APP_PATCH_FILE})
-    APP_REPO_BASENAME=$(get_git_basename ${APP_REPO})
 
-    if [[ ${GIT_REPO_BASENAME} == ${APP_REPO_BASENAME} ]] ; then
-      echo "Your working repo ${GIT_REPO}, matches your cluster overlay branch ${APP_REPO}"
-    else 
+    # Extract repoURL from configMapGenerator literal
+    OVERLAY_REPO=$(yq -r '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[]' ${CLUSTER_KUSTOMIZATION} | grep "^repoURL=" | cut -d= -f2)
+    OVERLAY_REPO_BASENAME=$(get_git_basename ${OVERLAY_REPO})
+
+    if [[ ${GIT_REPO_BASENAME} == ${OVERLAY_REPO_BASENAME} ]] ; then
+      echo "Your working repo ${GIT_REPO}, matches your cluster overlay repo ${OVERLAY_REPO}"
+    else
 
       GITHUB_URL="https://github.com/${GIT_REPO_BASENAME}.git"
 
@@ -310,11 +370,11 @@ check_repo(){
       echo "  ${GIT_REPO}"
       echo
       echo "Your cluster overlay repo is"
-      echo "  ${APP_REPO}"
+      echo "  ${OVERLAY_REPO}"
 
       if [[ ${FORCE} == "true" ]] ; then
         echo "Updating to ${GITHUB_URL}"
-        update_repo ${APP_PATCH_FILE} ${APP_PATCH_PATH} ${GITHUB_URL};
+        update_configmap_repo ${CLUSTER_KUSTOMIZATION} ${GITHUB_URL}
       else
 
         echo
@@ -326,7 +386,7 @@ check_repo(){
 
         select yn in "Yes" "No"; do
             case $yn in
-                Yes ) update_repo ${APP_PATCH_FILE} ${APP_PATCH_PATH} ${GITHUB_URL}; break;;
+                Yes ) update_configmap_repo ${CLUSTER_KUSTOMIZATION} ${GITHUB_URL}; break;;
                 No ) break;;
             esac
         done

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -306,7 +306,7 @@ update_configmap_repo(){
   echo "Updating ${KUSTOMIZATION_FILE}..."
 
   # Update the repoURL literal in the configMapGenerator
-  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | startswith("repoURL="))) = "repoURL='${REPO_URL}'"' ${KUSTOMIZATION_FILE}
+  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(test("^repoURL="))) = "repoURL='${REPO_URL}'"' ${KUSTOMIZATION_FILE}
 
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
@@ -335,7 +335,7 @@ update_configmap_branch(){
   echo "Updating ${KUSTOMIZATION_FILE}..."
 
   # Update the targetRevision literal in the configMapGenerator
-  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | startswith("targetRevision="))) = "targetRevision='${BRANCH}'"' ${KUSTOMIZATION_FILE}
+  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(test("^targetRevision="))) = "targetRevision='${BRANCH}'"' ${KUSTOMIZATION_FILE}
 
   git add ${KUSTOMIZATION_FILE}
   git commit -m "Update branch to ${BRANCH} (automatic update by bootstrap script)"

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -306,7 +306,7 @@ update_configmap_repo(){
   echo "Updating ${KUSTOMIZATION_FILE}..."
 
   # Update the repoURL literal in the configMapGenerator
-  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(test("^repoURL="))) = "repoURL='${REPO_URL}'"' ${KUSTOMIZATION_FILE}
+  sed -i "s|      - repoURL=.*|      - repoURL=${REPO_URL}|" ${KUSTOMIZATION_FILE}
 
   GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
@@ -335,7 +335,7 @@ update_configmap_branch(){
   echo "Updating ${KUSTOMIZATION_FILE}..."
 
   # Update the targetRevision literal in the configMapGenerator
-  yq -i '(.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(test("^targetRevision="))) = "targetRevision='${BRANCH}'"' ${KUSTOMIZATION_FILE}
+  sed -i "s|      - targetRevision=.*|      - targetRevision=${BRANCH}|" ${KUSTOMIZATION_FILE}
 
   git add ${KUSTOMIZATION_FILE}
   git commit -m "Update branch to ${BRANCH} (automatic update by bootstrap script)"

--- a/scripts/validate_git_config.sh
+++ b/scripts/validate_git_config.sh
@@ -171,12 +171,105 @@ verify_repo() {
   fi
 }
 
+verify_configmap_repo() {
+  if [ -z "$1" ]; then
+    echo "No kustomization file supplied."
+    exit 1
+  else
+    KUST_FILE=$1
+  fi
+
+  if [ -z "$2" ]; then
+    echo "No expected repo supplied."
+    exit 1
+  else
+    EXPECTED_REPO=$2
+  fi
+
+  if ${DEBUG}; then
+    echo "Verifying if ${KUST_FILE} configMapGenerator is set to ${EXPECTED_REPO}"
+  fi
+
+  # Extract repoURL from configMapGenerator
+  CONFIGMAP_REPO=$(yq -r '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[]' ${KUST_FILE} | grep "^repoURL=" | cut -d= -f2)
+
+  if [[ -z "${CONFIGMAP_REPO}" ]]; then
+    if ${DEBUG}; then
+      echo "Skipping ${KUST_FILE} - no configMapGenerator found"
+    fi
+    return 0
+  fi
+
+  if [[ "${CONFIGMAP_REPO}" != "${EXPECTED_REPO}" ]]; then
+    if ${GITHUB}; then
+      line_number=$(yq '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | contains("repoURL")) | line' ${KUST_FILE})
+      message="Expected \`${EXPECTED_REPO}\` but got \`${CONFIGMAP_REPO}\`"
+      echo "::error file=${KUST_FILE},line=${line_number},col=10,title=Incorrect Repo URL in ConfigMap::${message}"
+    else
+      echo "Expected ${KUST_FILE} configMapGenerator to be set to \`${EXPECTED_REPO}\` but got \`${CONFIGMAP_REPO}\`"
+    fi
+
+    ERROR_DETECTED=true
+  fi
+}
+
+verify_configmap_branch() {
+  if [ -z "$1" ]; then
+    echo "No kustomization file supplied."
+    exit 1
+  else
+    KUST_FILE=$1
+  fi
+
+  if [ -z "$2" ]; then
+    echo "No expected branch supplied."
+    exit 1
+  else
+    EXPECTED_BRANCH=$2
+  fi
+
+  if ${DEBUG}; then
+    echo "Verifying if ${KUST_FILE} configMapGenerator is set to ${EXPECTED_BRANCH}"
+  fi
+
+  # Extract targetRevision from configMapGenerator
+  CONFIGMAP_BRANCH=$(yq -r '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[]' ${KUST_FILE} | grep "^targetRevision=" | cut -d= -f2)
+
+  if [[ -z "${CONFIGMAP_BRANCH}" ]]; then
+    if ${DEBUG}; then
+      echo "Skipping ${KUST_FILE} - no configMapGenerator found"
+    fi
+    return 0
+  fi
+
+  if [[ "${CONFIGMAP_BRANCH}" != "${EXPECTED_BRANCH}" ]]; then
+    if ${GITHUB}; then
+      line_number=$(yq '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[] | select(. | contains("targetRevision")) | line' ${KUST_FILE})
+      message="Expected \`${EXPECTED_BRANCH}\` but got \`${CONFIGMAP_BRANCH}\`"
+      echo "::error file=${KUST_FILE},line=${line_number},col=10,title=Incorrect Branch in ConfigMap::${message}"
+    else
+      echo "Expected ${KUST_FILE} configMapGenerator to be set to \`${EXPECTED_BRANCH}\` but got \`${CONFIGMAP_BRANCH}\`"
+    fi
+
+    ERROR_DETECTED=true
+  fi
+}
+
 main() {
   APP_PATCH_FILE="./components/argocd/apps/base/cluster-config-app-of-apps.yaml"
   APP_PATCH_PATH=".spec.source.targetRevision"
 
+  # Validate base Application file
   verify_branch "${APP_PATCH_FILE}" ${EXPECTED_BRANCH}
   verify_repo "${APP_PATCH_FILE}" ${EXPECTED_REPO}
+
+  # Validate all cluster overlay ConfigMap generators
+  for overlay in clusters/overlays/*/kustomization.yaml; do
+    if [ -f "$overlay" ]; then
+      verify_configmap_branch "$overlay" ${EXPECTED_BRANCH}
+      verify_configmap_repo "$overlay" ${EXPECTED_REPO}
+    fi
+  done
 
   if ${ERROR_DETECTED}; then
     exit 1


### PR DESCRIPTION
## Summary

Improves the forking and customization experience by migrating from hardcoded git repository URLs in base Application manifests to overlay-specific ConfigMap generators.

**Key changes:**
- Add `configMapGenerator` to all 11 cluster overlays with `repoURL` and `targetRevision`
- Update Kustomize `replacements` to source from ConfigMap instead of Application
- Inject git URL into both Applications and ApplicationSets
- Modify bootstrap script to auto-detect and update overlay ConfigMaps

## Benefits

✅ **Base files remain pristine** - No modifications needed when forking  
✅ **Overlay-specific configuration** - Each deployment has its own git config  
✅ **Single source of truth** - One ConfigMap per overlay  
✅ **No merge conflicts** - Upstream base files never modified  
✅ **Automated detection** - Bootstrap script auto-detects fork URL  

## Technical Details

**Pattern borrowed from:** [OCP Open Environment Install Tool](https://github.com/redhat-cop/ocp-open-env-install-tool)

**Before (old pattern):**
```yaml
# components/argocd/apps/base/cluster-config-app-of-apps.yaml
spec:
  source:
    repoURL: https://github.com/redhat-ai-services/ai-accelerator.git  # ❌ Hardcoded
```

**After (new pattern):**
```yaml
# clusters/overlays/rhoai-stable-2.22/kustomization.yaml
configMapGenerator:
  - name: gitops-repo-config
    literals:
      - repoURL=https://github.com/YOUR-FORK/ai-accelerator.git  # ✅ Overlay-specific
      - targetRevision=main

replacements:
  - source:
      kind: ConfigMap
      name: gitops-repo-config
      fieldPath: data.repoURL
    targets:
      - select: {kind: Application}
        fieldPaths: [spec.source.repoURL]
      - select: {kind: ApplicationSet}
        fieldPaths: [spec.template.spec.source.repoURL]
```

## Overlays Updated

All 11 cluster overlays migrated:
- `rhoai-eus-2.16`, `rhoai-eus-2.16-aws-gpu`
- `rhoai-fast`, `rhoai-fast-3.x-aws-gpu`, `rhoai-fast-aws-gpu`
- `rhoai-stable-2.19`, `rhoai-stable-2.19-aws-gpu`
- `rhoai-stable-2.22`, `rhoai-stable-2.22-aws-gpu`
- `rhoai-stable-2.25`, `rhoai-stable-2.25-aws-gpu`

## Bootstrap Script Changes

Updated functions in `scripts/functions.sh`:
- `check_repo()` - Reads from overlay ConfigMap instead of base Application
- `check_branch()` - Reads from overlay ConfigMap instead of base Application
- `update_configmap_repo()` - New function to update overlay repoURL
- `update_configmap_branch()` - New function to update overlay targetRevision

## Test Plan

- [x] Verified all 11 overlays build successfully with `oc kustomize --enable-helm`
- [x] Confirmed ConfigMaps generated with correct hash
- [x] Validated URLs injected into Applications
- [x] Validated URLs injected into ApplicationSets
- [x] Tested bootstrap script URL extraction logic
- [x] No changes to base Application files

## Related Work

Follows PR #169 which added alphabetical sorting standards to kustomization.yaml files. Both changes improve consistency and adopt patterns from the OCP Open Env Install Tool project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)