### PR TITLE
Fix stable-3.3 overlays to the stable-3.3 channel

### DIFF
--- a/components/operators/openshift-ai/aggregate/overlays/stable-3.3-nvidia-gpu/kustomization.yaml
+++ b/components/operators/openshift-ai/aggregate/overlays/stable-3.3-nvidia-gpu/kustomization.yaml
@@ -5,5 +5,5 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - ../../../instance-3.x/overlays/stable-3.x-nvidia-gpu
-  - ../../../operator/overlays/stable-3.x
+  - ../../../instance-3.x/overlays/stable-3.3-nvidia-gpu
+  - ../../../operator/overlays/stable-3.3


### PR DESCRIPTION
# What does this PR do?
Fixed the overlay channel as it was marked as 3.x but it is 3.3, I installed it and I previously got 3.4.

Tested the change, it works on a fresh cluster.