### PR TITLE
fix: Update patch-operators-list.yaml OpenShift AI Operator line

### DIFF
--- a/components/argocd/apps/overlays/rhoai-eus-2.25-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-eus-2.25-aws-gpu/patch-operators-list.yaml
@@ -30,7 +30,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: openshift-ai-operator
-          path: components/operators/openshift-ai/aggregate/overlays/fast-nvidia-gpu
+          path: components/operators/openshift-ai/aggregate/overlays/eus-2.25-nvidia-gpu
       - cluster: local
         url: https://kubernetes.default.svc
         values:


### PR DESCRIPTION
ArgoCD wasn't installing OpenShift AI Operator as the previous directory could not be found. Switched to use the new dir relating to EUS 2.25. 

# What does this PR do?
Change a line to point to the correct directory
