### PR TITLE
Add Sovereign AI Cisco bare-metal and RHDP overlays

### DIFF
--- a/bootstrap/overlays/sovereign-ai-cisco/kustomization.yaml
+++ b/bootstrap/overlays/sovereign-ai-cisco/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../clusters/overlays/sovereign-ai-cisco
+  - ../../base

--- a/bootstrap/overlays/sovereign-ai-rhdp/kustomization.yaml
+++ b/bootstrap/overlays/sovereign-ai-rhdp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../clusters/overlays/sovereign-ai-rhdp
+  - ../../base

--- a/clusters/overlays/sovereign-ai-cisco/kustomization.yaml
+++ b/clusters/overlays/sovereign-ai-cisco/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+  - ../../../components/argocd/apps/overlays/sovereign-ai-cisco
+  - ../../base
+# patches:
+# Uncomment to disable automatic sync (useful when troubleshooting)
+# - path: patch-applicationset-manual-sync.yaml
+#   target:
+#     group: argoproj.io
+#     version: v1alpha1
+#     kind: ApplicationSet
+# - path: patch-application-manual-sync.yaml
+#   target:
+#     group: argoproj.io
+#     kind: Application
+#     version: v1alpha1
+
+# Git repository configuration (single source of truth for all Applications and ApplicationSets)
+# Same repo as sovereign-ai-rhdp — only the cluster overlay differs.
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/DevoteamNL/sovereign-ai-gitops.git
+      - targetRevision=main
+
+replacements:
+  - source:
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
+    targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
+      - select:
+          kind: ApplicationSet
+        fieldPaths:
+          - spec.template.spec.source.repoURL
+  - source:
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
+    targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
+      - select:
+          kind: ApplicationSet
+        fieldPaths:
+          - spec.template.spec.source.targetRevision

--- a/clusters/overlays/sovereign-ai-cisco/patch-application-manual-sync.yaml
+++ b/clusters/overlays/sovereign-ai-cisco/patch-application-manual-sync.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/syncPolicy

--- a/clusters/overlays/sovereign-ai-cisco/patch-applicationset-manual-sync.yaml
+++ b/clusters/overlays/sovereign-ai-cisco/patch-applicationset-manual-sync.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy

--- a/clusters/overlays/sovereign-ai-rhdp/kustomization.yaml
+++ b/clusters/overlays/sovereign-ai-rhdp/kustomization.yaml
@@ -1,0 +1,56 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-gitops
+
+resources:
+  - ../../../components/argocd/apps/overlays/sovereign-ai-rhdp
+  - ../../base
+# patches:
+# Uncomment to disable automatic sync (useful when troubleshooting)
+# - path: patch-applicationset-manual-sync.yaml
+#   target:
+#     group: argoproj.io
+#     version: v1alpha1
+#     kind: ApplicationSet
+# - path: patch-application-manual-sync.yaml
+#   target:
+#     group: argoproj.io
+#     kind: Application
+#     version: v1alpha1
+
+# Git repository configuration (single source of truth for all Applications and ApplicationSets)
+
+configMapGenerator:
+  - name: gitops-repo-config
+    literals:
+      - repoURL=https://github.com/DevoteamNL/sovereign-ai-gitops.git
+      - targetRevision=main
+
+replacements:
+  - source:
+      kind: ConfigMap
+      fieldPath: data.repoURL
+      name: gitops-repo-config
+    targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.repoURL
+      - select:
+          kind: ApplicationSet
+        fieldPaths:
+          - spec.template.spec.source.repoURL
+  - source:
+      kind: ConfigMap
+      fieldPath: data.targetRevision
+      name: gitops-repo-config
+    targets:
+      - select:
+          kind: Application
+        fieldPaths:
+          - spec.source.targetRevision
+      - select:
+          kind: ApplicationSet
+        fieldPaths:
+          - spec.template.spec.source.targetRevision

--- a/clusters/overlays/sovereign-ai-rhdp/machinesets/g6e-machineset.yaml
+++ b/clusters/overlays/sovereign-ai-rhdp/machinesets/g6e-machineset.yaml
@@ -1,0 +1,67 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: ${CLUSTER_ID}-g6e-${AZ}
+  namespace: openshift-machine-api
+  labels:
+    machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+      machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-g6e-${AZ}
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: ${CLUSTER_ID}
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: ${CLUSTER_ID}-g6e-${AZ}
+        node-role.kubernetes.io/gpu: ''
+        node-role.kubernetes.io/worker: ''
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/gpu: ''
+      taints:
+        - key: nvidia.com/gpu
+          value: "true"
+          effect: NoSchedule
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1beta1
+          kind: AWSMachineProviderConfig
+          ami:
+            id: ${AMI_ID}
+          instanceType: g6e.2xlarge
+          iamInstanceProfile:
+            id: ${CLUSTER_ID}-worker-profile
+          credentialsSecret:
+            name: aws-cloud-credentials
+          placement:
+            region: us-east-2
+            availabilityZone: ${AZ}
+          securityGroups:
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - ${CLUSTER_ID}-node
+            - filters:
+                - name: 'tag:Name'
+                  values:
+                    - ${CLUSTER_ID}-lb
+          subnet:
+            filters:
+              - name: 'tag:Name'
+                values:
+                  - ${CLUSTER_ID}-subnet-private-${AZ}
+          userDataSecret:
+            name: worker-user-data
+          publicIp: false
+          blockDevices:
+            - ebs:
+                encrypted: true
+                iops: 0
+                volumeSize: 200
+                volumeType: gp2

--- a/clusters/overlays/sovereign-ai-rhdp/patch-application-manual-sync.yaml
+++ b/clusters/overlays/sovereign-ai-rhdp/patch-application-manual-sync.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/syncPolicy

--- a/clusters/overlays/sovereign-ai-rhdp/patch-applicationset-manual-sync.yaml
+++ b/clusters/overlays/sovereign-ai-rhdp/patch-applicationset-manual-sync.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy

--- a/components/argocd/apps/overlays/sovereign-ai-cisco/kustomization.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-cisco/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patch-cluster-config-app-of-apps.yaml
+    target:
+      kind: Application
+      name: cluster-config-app-of-apps
+  - path: patch-operators-list.yaml
+    target:
+      kind: ApplicationSet
+      name: cluster-operators
+  - path: patch-configs-list.yaml
+    target:
+      kind: ApplicationSet
+      name: cluster-configs

--- a/components/argocd/apps/overlays/sovereign-ai-cisco/patch-cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-cisco/patch-cluster-config-app-of-apps.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-config-app-of-apps
+spec:
+  source:
+    path: clusters/overlays/sovereign-ai-cisco

--- a/components/argocd/apps/overlays/sovereign-ai-cisco/patch-configs-list.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-cisco/patch-configs-list.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-configs
+spec:
+  generators:
+  - list:
+      elements:
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: user-workload-monitoring
+          path: components/cluster-configs/user-workload-monitoring/overlays/default
+      # Same RAG tenant as sovereign-ai-rhdp — reused unchanged.
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: sovereign-ai-rag
+          path: tenants/sovereign-ai-rag

--- a/components/argocd/apps/overlays/sovereign-ai-cisco/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-cisco/patch-operators-list.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-operators
+spec:
+  generators:
+  - list:
+      elements:
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: nfd-operator
+          path: components/operators/nfd/aggregate/overlays/default
+      # Bare metal: use the non-AWS GPU overlay (no aws-gpu-machineset job,
+      # no aws-creds lookup). GPU nodes are physical, added out-of-band.
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: nvidia-gpu-operator
+          path: components/operators/gpu-operator-certified/aggregate/overlays/default
+      # RHOAI 3.x (stable channel) — correct for OCP 4.20. In 3.x KServe
+      # defaults to raw deployment, so no Service Mesh / Serverless required.
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: openshift-ai-operator
+          path: components/operators/openshift-ai/aggregate/overlays/sovereign-ai-cisco
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: openshift-gitops-operator
+          path: components/operators/openshift-gitops/aggregate/overlays/rhdp

--- a/components/argocd/apps/overlays/sovereign-ai-rhdp/kustomization.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-rhdp/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patch-cluster-config-app-of-apps.yaml
+    target:
+      kind: Application
+      name: cluster-config-app-of-apps
+  - path: patch-operators-list.yaml
+    target:
+      kind: ApplicationSet
+      name: cluster-operators
+  - path: patch-configs-list.yaml
+    target:
+      kind: ApplicationSet
+      name: cluster-configs

--- a/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-cluster-config-app-of-apps.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-cluster-config-app-of-apps.yaml
@@ -1,0 +1,7 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-config-app-of-apps
+spec:
+  source:
+    path: clusters/overlays/sovereign-ai-rhdp

--- a/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-configs-list.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-configs-list.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-configs
+spec:
+  generators:
+  - list:
+      elements:
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: user-workload-monitoring
+          path: components/cluster-configs/user-workload-monitoring/overlays/default
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: sovereign-ai-rag
+          path: tenants/sovereign-ai-rag

--- a/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/sovereign-ai-rhdp/patch-operators-list.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-operators
+spec:
+  generators:
+  - list:
+      elements:
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: nfd-operator
+          path: components/operators/nfd/aggregate/overlays/default
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: nvidia-gpu-operator
+          path: components/operators/gpu-operator-certified/aggregate/overlays/aws
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: openshift-ai-operator
+          path: components/operators/openshift-ai/aggregate/overlays/sovereign-ai-rhdp
+      - cluster: local
+        url: https://kubernetes.default.svc
+        values:
+          name: openshift-gitops-operator
+          path: components/operators/openshift-gitops/aggregate/overlays/rhdp

--- a/components/operators/openshift-ai/aggregate/overlays/sovereign-ai-cisco/kustomization.yaml
+++ b/components/operators/openshift-ai/aggregate/overlays/sovereign-ai-cisco/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - ../../../instance-3.x/overlays/sovereign-ai-cisco
+  - ../../../operator/overlays/stable-3.x

--- a/components/operators/openshift-ai/aggregate/overlays/sovereign-ai-rhdp/kustomization.yaml
+++ b/components/operators/openshift-ai/aggregate/overlays/sovereign-ai-rhdp/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+resources:
+  - ../../../instance-2.x/overlays/sovereign-ai-rhdp
+  - ../../../operator/overlays/stable

--- a/components/operators/openshift-ai/instance-2.x/base/kustomization.yaml
+++ b/components/operators/openshift-ai/instance-2.x/base/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - datasciencecluster.yaml
   - dsc-init.yaml
   - namespace.yaml
-  - odhdashboardconfig.yaml

--- a/components/operators/openshift-ai/instance-2.x/components/components-datasciencepipelines/kustomization.yaml
+++ b/components/operators/openshift-ai/instance-2.x/components/components-datasciencepipelines/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: patch-datasciencecluster.yaml
+    target:
+      kind: DataScienceCluster

--- a/components/operators/openshift-ai/instance-2.x/components/components-datasciencepipelines/patch-datasciencecluster.yaml
+++ b/components/operators/openshift-ai/instance-2.x/components/components-datasciencepipelines/patch-datasciencecluster.yaml
@@ -1,0 +1,8 @@
+kind: DataScienceCluster
+apiVersion: datasciencecluster.opendatahub.io/v1
+metadata:
+  name: default
+spec:
+  components:
+    datasciencepipelines:
+      managementState: Managed

--- a/components/operators/openshift-ai/instance-2.x/overlays/sovereign-ai-rhdp/kustomization.yaml
+++ b/components/operators/openshift-ai/instance-2.x/overlays/sovereign-ai-rhdp/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ../../components/components-datasciencepipelines
+  - ../../components/components-kserve-rawdeployments-only
+  - ../../components/components-llamastack
+  - ../../components/components-modelregistry
+  - ../../components/hardware-profiles-nvidia-gpu
+  - ../../components/idle-notebook-culling
+  - ../../components/make-kubeadmin-cluster-admin
+  - ../../components/rhoai-auth

--- a/components/operators/openshift-ai/instance-3.x/base/kustomization.yaml
+++ b/components/operators/openshift-ai/instance-3.x/base/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
   - datasciencecluster.yaml
   - dsc-init.yaml
   - namespace.yaml
-  - odhdashboardconfig.yaml

--- a/components/operators/openshift-ai/instance-3.x/overlays/sovereign-ai-cisco/kustomization.yaml
+++ b/components/operators/openshift-ai/instance-3.x/overlays/sovereign-ai-cisco/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# DataScienceCluster component selection for this overlay, mapped from the
+# 2.x sovereign-ai-rhdp set to 3.x equivalents:
+#   2.x components-datasciencepipelines        -> 3.x components-aipipelines
+#   2.x components-kserve-rawdeployments-only   -> 3.x components-kserve (raw is the 3.x default)
+#   2.x components-llamastack / -modelregistry  -> unchanged
+#   2.x make-kubeadmin-cluster-admin            -> not present in 3.x, dropped
+# Intentionally omitted vs the full stable-3.x-nvidia-gpu overlay (add if
+# needed): components-feast, -ray, -trainingoperator, -trustyai,
+# -workbenches, -kserve-maas, inference-gateway.
+components:
+  - ../../components/components-aipipelines
+  - ../../components/components-kserve
+  - ../../components/components-llamastack
+  - ../../components/components-modelregistry
+  - ../../components/hardware-profiles-nvidia-gpu
+  - ../../components/idle-notebook-culling
+  - ../../components/rhoai-auth

--- a/components/operators/openshift-ai/operator/overlays/stable-3.x/patch-channel.yaml
+++ b/components/operators/openshift-ai/operator/overlays/stable-3.x/patch-channel.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/channel
-  value: stable-3.x
+  value: stable

--- a/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencepipelineapplication-health-check.yaml
+++ b/components/operators/openshift-gitops/instance/components/health-check-openshift-ai/patch-datasciencepipelineapplication-health-check.yaml
@@ -12,7 +12,7 @@
           degraded = false
           for i, condition in pairs(obj.status.conditions) do
 
-            if condition.status == "False" then
+            if condition.status == "False" and condition.reason ~= "NotApplicable" then
               progressing = true
               msg = msg .. i .. ": " .. condition.type .. " | " .. condition.status .. " | " .. condition.reason .. " | " .. condition.message .. "\n"
             end

--- a/tenants/sovereign-ai-rag/kustomization.yaml
+++ b/tenants/sovereign-ai-rag/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rag-application.yaml

--- a/tenants/sovereign-ai-rag/rag-application.yaml
+++ b/tenants/sovereign-ai-rag/rag-application.yaml
@@ -1,0 +1,46 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lasagna-rag
+  namespace: openshift-gitops
+  labels:
+    gitops.ownedBy: cluster-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  destination:
+    namespace: lasagna-rag
+    server: https://kubernetes.default.svc
+  project: cluster-config
+  source:
+    repoURL: https://github.com/DevoteamNL/sovereign-ai-rag.git
+    targetRevision: main
+    path: deploy/helm/rag
+    helm:
+      valuesObject:
+        global:
+          models:
+            llama-3-2-3b-instruct:
+              enabled: true
+              tolerations:
+                - key: nvidia.com/gpu
+                  effect: NoSchedule
+                  operator: Exists
+            llama-guard-3-8b:
+              enabled: true
+              tolerations:
+                - key: nvidia.com/gpu
+                  effect: NoSchedule
+                  operator: Exists
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - SkipDryRunOnMissingResource=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 20m


### PR DESCRIPTION
# What does this PR do?
Adds the deployable GitOps overlays for the Sovereign AI factory: Cisco bare-metal (RHOAI 3.x) and Red Hat Demo Platform (RHOAI 2.x + AWS GPU machineset) cluster overlays, the RAG tenant Application, and three base-file fixes carried over from production use (DSPA health check ignoring NotApplicable conditions, the rhods-operator OLM channel value, and dropping OdhDashboardConfig from the instance base).