### PR TITLE
Fix repoURL corruption from get_git_basename URL parsing bug

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -263,8 +263,24 @@ get_git_basename(){
     REPO_URL=$1
   fi
 
-  QUERY='s#(git@|https://)github.com[:/]([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)\.git#\2#'
-  REPO_BASENAME=$(echo ${REPO_URL} | sed -E  ${QUERY})
+  # Normalize the URL before parsing so we handle all the ways people
+  # clone a repo: with/without a trailing slash, and with/without a
+  # trailing ".git" suffix (e.g. "org/repo/", "org/repo/.git", "org/repo.git", "org/repo").
+  NORMALIZED_URL=${REPO_URL%/}
+  NORMALIZED_URL=${NORMALIZED_URL%.git}
+  NORMALIZED_URL=${NORMALIZED_URL%/}
+
+  QUERY='s#^(git@|https://)github\.com[:/]([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)$#\2#'
+  REPO_BASENAME=$(echo "${NORMALIZED_URL}" | sed -E "${QUERY}")
+
+  # If the pattern didn't match (e.g. an unexpected/malformed URL), sed
+  # returns the input unchanged. Detect that instead of silently passing
+  # a bogus value back to callers who will build a new URL out of it.
+  if [[ "${REPO_BASENAME}" == "${NORMALIZED_URL}" ]] || [[ ! "${REPO_BASENAME}" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]]; then
+    echo "Unable to parse '${REPO_URL}' as a github.com org/repo URL." >&2
+    return 1
+  fi
+
   echo ${REPO_BASENAME}
 }
 
@@ -364,11 +380,17 @@ check_repo(){
   else
 
     GIT_REPO=$(git config --get remote.origin.url)
-    GIT_REPO_BASENAME=$(get_git_basename ${GIT_REPO})
+    if ! GIT_REPO_BASENAME=$(get_git_basename ${GIT_REPO}); then
+      print_warning "Unable to parse your git remote (${GIT_REPO}). Skipping repo URL check."
+      return
+    fi
 
     # Extract repoURL from configMapGenerator literal
     OVERLAY_REPO=$(yq -r '.configMapGenerator[] | select(.name == "gitops-repo-config") | .literals[]' ${CLUSTER_KUSTOMIZATION} | grep "^repoURL=" | cut -d= -f2)
-    OVERLAY_REPO_BASENAME=$(get_git_basename ${OVERLAY_REPO})
+    if ! OVERLAY_REPO_BASENAME=$(get_git_basename ${OVERLAY_REPO}); then
+      print_warning "Unable to parse the repo URL in ${CLUSTER_KUSTOMIZATION} (${OVERLAY_REPO}). Skipping repo URL check."
+      return
+    fi
 
     if [[ ${GIT_REPO_BASENAME} == ${OVERLAY_REPO_BASENAME} ]] ; then
       echo "Your working repo ${GIT_REPO}, matches your cluster overlay repo ${OVERLAY_REPO}"


### PR DESCRIPTION
# What does this PR do?

`get_git_basename()` in `scripts/functions.sh` required the input URL to end in a
literal `.git` suffix. When a git remote didn't match that exact shape (e.g. missing
`.git`, or having a trailing slash like `https://github.com/org/repo/`), the regex
silently failed to match and `sed` returned the **entire input URL unchanged**
instead of just `org/repo`.

`check_repo()` then blindly prepended `https://github.com/` to that unparsed value
to build a new `repoURL`, producing a doubled URL such as:

    https://github.com/https://github.com/org/repo/.git

which got auto-committed into a cluster overlay's `kustomization.yaml` during
`bootstrap.sh`, breaking ArgoCD's ability to sync from the repo.

This PR:
- Normalizes the input URL in `get_git_basename()` (strips trailing slash, trailing
  `.git`, then a further trailing slash) before parsing, so it correctly handles all
  common remote formats: `https://github.com/org/repo`, `.../org/repo/`,
  `.../org/repo.git`, `.../org/repo/.git`, and the `git@github.com:org/repo(.git)`
  SSH form.
- Makes `get_git_basename()` fail loudly (non-zero return + stderr message) instead
  of silently echoing back an unparsed URL when it can't confidently extract
  `org/repo`.
- Updates `check_repo()` to check for that failure and skip the auto-fix (with a
  warning) rather than building and committing a corrupted `repoURL`.
- Fixes the already-corrupted `repoURL` in
  `clusters/overlays/rhoai-stable-3.4-aws-gpu/kustomization.yaml`.

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] Relevant documentation has been updated
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan

Ran `get_git_basename()` against a matrix of real-world remote URL shapes and
confirmed correct `org/repo` extraction, including the exact malformed URL that
previously caused the bug:

- `https://github.com/org/repo.git` → `org/repo`
- `https://github.com/org/repo` → `org/repo`
- `https://github.com/org/repo/` → `org/repo`
- `https://github.com/org/repo/.git` → `org/repo`
- `git@github.com:org/repo.git` → `org/repo`
- `git@github.com:org/repo` → `org/repo`
- `git@github.com:org/repo/` → `org/repo`
- `https://github.com/https://github.com/org/repo/.git` → parse error (no longer silently corrupted)
- `https://gitlab.com/org/repo.git` → parse error (non-GitHub URL correctly rejected)

Also re-ran `scripts/bootstrap.sh` locally against a clean clone to confirm
`check_repo()` no longer double-prefixes the URL and the cluster overlay's
`repoURL` remains correct after bootstrap.