### PR TITLE
Pin ClusterObservabilityOperator version for RHOAI 3.4 observability (TP) to work

### DIFF
--- a/components/argocd/apps/overlays/rhoai-stable-3.4-aws-gpu/patch-operators-list.yaml
+++ b/components/argocd/apps/overlays/rhoai-stable-3.4-aws-gpu/patch-operators-list.yaml
@@ -10,7 +10,7 @@ spec:
         url: https://kubernetes.default.svc
         values:
           name: cluster-observability-operator
-          path: components/operators/cluster-observability-operator/operator/overlays/stable
+          path: components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0
       - cluster: local
         url: https://kubernetes.default.svc
         values:

--- a/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/kustomization.yaml
+++ b/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Subscription
+      name: cluster-observability-operator
+    path: patch-channel.yaml
+  - target:
+      kind: Subscription
+      name: cluster-observability-operator
+    path: patch-version-pinning.yaml

--- a/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/patch-channel.yaml
+++ b/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/patch-channel.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable

--- a/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/patch-version-pinning.yaml
+++ b/components/operators/cluster-observability-operator/operator/overlays/stable-1.4.0/patch-version-pinning.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/installPlanApproval
+  value: Manual
+- op: add
+  path: /spec/startingCSV
+  value: cluster-observability-operator.v1.4.0


### PR DESCRIPTION
# What does this PR do?
Integrated Observability (TP) in RHOAI 3.4 doesn't work with the latest ClusterObservabilityOperator (COO) (i.e. v1.5.0 & v1.5.1) and the Observability section in RHOAI Dashboard show errors instead of data. This is probably due to the new Perses related API changes ([introduced from 1.5.0](https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest/html-single/red_hat_openshift_cluster_observability_operator_release_notes/index#cluster-observability-operator-1-5-new-features-enhancements_cluster-observability-operator-release-notes)) that RHOAI 3.4 didn't consider yet. 

Pinning COO to 1.4.0 doesn't cause this issue and data are visible in RHOAI Dashboard.

## Checklist
- [x] You have completed the described test plan and included screenshots in the PR or comments showing the results
- [x] You have squashed commits (including commits to test from your branch) to be logical and reduce unnecessary commits

## Test Plan
Enable RHOAI Observability and opening "Observe & Monitor" section in RHOAI 3.4 dashboard shows the metrics:
<img width="1883" height="912" alt="image" src="https://github.com/user-attachments/assets/574c6671-7bbf-44cc-8b8d-eeb0a04ff24a" />
 

